### PR TITLE
Add OpenRouter chat completion utility

### DIFF
--- a/app/mcp_tools/__init__.py
+++ b/app/mcp_tools/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for working with LLM text chat."""
+
+from .llm_text import chat
+
+__all__ = ["chat"]

--- a/app/mcp_tools/llm_text.py
+++ b/app/mcp_tools/llm_text.py
@@ -1,0 +1,65 @@
+"""Simple wrapper around OpenRouter chat completions."""
+from __future__ import annotations
+
+import os
+import time
+from typing import Dict, List, Optional
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+class OpenRouterError(RuntimeError):
+    """Raised when interaction with OpenRouter fails."""
+
+
+def _get_env(key: str) -> str:
+    value = os.getenv(key)
+    if not value:
+        raise OpenRouterError(f"Environment variable {key} is not set")
+    return value
+
+
+def chat(
+    messages: List[Dict],
+    model: Optional[str] = None,
+    max_tokens: int = 200,
+) -> str:
+    """Call OpenRouter chat completions API.
+
+    Args:
+        messages: Conversation messages in OpenAI format.
+        model: Model name; defaults to ``OPENROUTER_TEXT_MODEL`` env var.
+        max_tokens: Maximum tokens for completion.
+
+    Returns:
+        The generated text from the first choice.
+
+    Raises:
+        OpenRouterError: If configuration is missing or the request fails.
+    """
+
+    api_key = _get_env("OPENROUTER_API_KEY")
+    if model is None:
+        model = _get_env("OPENROUTER_TEXT_MODEL")
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {"model": model, "max_tokens": max_tokens, "messages": messages}
+
+    delays = [0.5, 1, 2]
+    for attempt in range(len(delays) + 1):
+        try:
+            response = requests.post(
+                API_URL, json=payload, headers=headers, timeout=20
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["choices"][0]["message"]["content"]
+        except Exception as exc:  # noqa: BLE001
+            if attempt == len(delays):
+                raise OpenRouterError(f"OpenRouter API request failed: {exc}") from None
+            time.sleep(delays[attempt])


### PR DESCRIPTION
## Summary
- add `chat` helper to call OpenRouter chat completions with retries and env validation
- expose helper via `app.mcp_tools` package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a37c9e0798833094d7ee05f99a9066