### PR TITLE
feat: add logging for MCP tool calls

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -22,6 +22,7 @@ from .tools.tts import speak_to_file
 from .tools.anki_tool import add_basic_note
 from .orchestration.pipeline import LessonConfig, build_lesson
 from .mcp_tools.lesson import make_card as make_lesson_card
+from .tool_logging import log_tool
 
 
 def lesson_make_card(word: str, lang: str, deck: str, tag: str) -> dict:
@@ -39,32 +40,32 @@ def create_server() -> "Server":  # type: ignore[return-type]
 
     server = Server("language-assistant")
 
-    @server.tool("transcript.get")
+    @log_tool(server, "transcript.get")
     async def transcript_get(url: str) -> str:
         return fetch_transcript(url)
 
-    @server.tool("vocab.extract")
+    @log_tool(server, "vocab.extract")
     async def vocab_extract(text: str, limit: int = 20):
         return extract_vocab(text, limit=limit)
 
-    @server.tool("grammar.check")
+    @log_tool(server, "grammar.check")
     async def grammar_check(text: str, language: str = "de"):
         return check_text(text, language=language)
 
-    @server.tool("tts.speak")
+    @log_tool(server, "tts.speak")
     async def tts_speak(text: str, voice: str = "de-DE") -> str:
         return speak_to_file(text, f"tts_{abs(hash(text))}.mp3", voice=voice)
 
-    @server.tool("anki.add_note")
+    @log_tool(server, "anki.add_note")
     async def anki_add_note(front: str, back: str, deck: str, tags: List[str] | None = None):
         return add_basic_note(front, back, deck, tags=tags)
 
-    @server.tool("lesson.build")
+    @log_tool(server, "lesson.build")
     async def lesson_build(url: str, deck: str, tag: str = "auto", limit: int = 15):
         cfg = LessonConfig(url=url, deck=deck, tag=tag, limit=limit)
         return build_lesson(cfg)
 
-    @server.tool("lesson.make_card")
+    @log_tool(server, "lesson.make_card")
     async def lesson_make_card_tool(word: str, lang: str, deck: str, tag: str) -> dict:
         # единая точка вызова для создания карточки
         return make_lesson_card(word, lang, deck, tag)

--- a/app/tool_logging.py
+++ b/app/tool_logging.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+import traceback
+from functools import wraps
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger("mcp.tools")
+
+_DEFAULT_SENSITIVE = {"token", "password", "secret", "api_key", "key"}
+
+
+def _filter_args(bound: inspect.BoundArguments, sensitive: set[str]) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    for name, value in bound.arguments.items():
+        lname = name.lower()
+        if lname in sensitive or any(k in lname for k in sensitive):
+            data[name] = "***"
+        else:
+            data[name] = value
+    return data
+
+
+def log_tool(server: Any, name: str, *, sensitive_fields: Iterable[str] | None = None) -> Callable:
+    """Decorator that registers a tool on ``server`` and logs its execution."""
+    sensitive = {s.lower() for s in (sensitive_fields or [])} | _DEFAULT_SENSITIVE
+
+    def decorator(func: Callable):
+        is_coro = inspect.iscoroutinefunction(func)
+        sig = inspect.signature(func)
+
+        if is_coro:
+            @wraps(func)
+            async def wrapper(*args, **kwargs):
+                bound = sig.bind_partial(*args, **kwargs)
+                filtered = _filter_args(bound, sensitive)
+                logger.info("%s start %s", name, filtered)
+                start = time.perf_counter()
+                try:
+                    result = await func(*args, **kwargs)
+                    dur = time.perf_counter() - start
+                    logger.info("%s ok %.3fs", name, dur)
+                    logger.debug("%s result=%s", name, result)
+                    return result
+                except Exception as exc:  # noqa: BLE001
+                    dur = time.perf_counter() - start
+                    logger.warning("%s err %s %.3fs", name, exc, dur)
+                    logger.debug("%s traceback:\n%s", name, traceback.format_exc())
+                    raise
+        else:
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                bound = sig.bind_partial(*args, **kwargs)
+                filtered = _filter_args(bound, sensitive)
+                logger.info("%s start %s", name, filtered)
+                start = time.perf_counter()
+                try:
+                    result = func(*args, **kwargs)
+                    dur = time.perf_counter() - start
+                    logger.info("%s ok %.3fs", name, dur)
+                    logger.debug("%s result=%s", name, result)
+                    return result
+                except Exception as exc:  # noqa: BLE001
+                    dur = time.perf_counter() - start
+                    logger.warning("%s err %s %.3fs", name, exc, dur)
+                    logger.debug("%s traceback:\n%s", name, traceback.format_exc())
+                    raise
+
+        return server.tool(name)(wrapper)
+
+    return decorator


### PR DESCRIPTION
## Summary
- log all MCP tool invocations via new `log_tool` decorator
- wrap server tools with logging to track parameters, duration and status

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a383b2bac88330b51418b8361a538d