### PR TITLE
Добавлен n8n workflow для отправки слов в Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ DEEPL_API_KEY=...
 OPENAI_API_KEY=...
 ```
 
+## n8n workflow
+
+Готовый workflow лежит в `examples/n8n-word-to-telegram.json`.
+
+1. Запустите n8n, передав переменные окружения:
+   - `TELEGRAM_BOT_TOKEN` — токен бота Telegram.
+   - `MCP_BASE_URL` — адрес MCP‑прокси или локального stdio‑bridge.
+2. В интерфейсе n8n выберите **Import from File** и загрузите `examples/n8n-word-to-telegram.json`.
+3. Откройте узлы **Send Photo** и **Send Text** и укажите `chatId` чата, куда слать карточки.
+4. Активируйте workflow. Webhook будет доступен по адресу `http://<host>/webhook/word`.
+5. Отправьте POST с JSON `{"word": "Haus"}` — в Telegram придёт текст и фото (если найдено).
+
 ## Тесты
 
 ```bash

--- a/examples/n8n-word-to-telegram.json
+++ b/examples/n8n-word-to-telegram.json
@@ -1,0 +1,142 @@
+{
+  "name": "Word to Telegram",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "word",
+        "method": "POST",
+        "responseMode": "onReceived"
+      },
+      "id": "1",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$env.MCP_BASE_URL}}/word",
+        "responseFormat": "json",
+        "jsonParameters": true,
+        "bodyParametersJson": "={\"word\": $json[\"word\"]}"
+      },
+      "id": "2",
+      "name": "MCP Lookup",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "string": [
+            {
+              "value1": "={{$json[\"image\"]}}",
+              "operation": "isNotEmpty"
+            }
+          ]
+        }
+      },
+      "id": "3",
+      "name": "Has image?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        650,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "sendPhoto",
+        "chatId": "123456789",
+        "photo": "={{$json[\"image\"]}}",
+        "additionalFields": {
+          "caption": "={{$json[\"text\"]}}"
+        }
+      },
+      "id": "4",
+      "name": "Send Photo",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [
+        850,
+        200
+      ],
+      "credentials": {
+        "telegramApi": {
+          "apiToken": "={{$env.TELEGRAM_BOT_TOKEN}}"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "sendMessage",
+        "chatId": "123456789",
+        "text": "={{$json[\"text\"]}}",
+        "additionalFields": {}
+      },
+      "id": "5",
+      "name": "Send Text",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [
+        850,
+        400
+      ],
+      "credentials": {
+        "telegramApi": {
+          "apiToken": "={{$env.TELEGRAM_BOT_TOKEN}}"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "MCP Lookup",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "MCP Lookup": {
+      "main": [
+        [
+          {
+            "node": "Has image?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has image?": {
+      "main": [
+        [
+          {
+            "node": "Send Photo",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Send Text",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add n8n workflow json: webhook -> MCP -> Telegram photo/text
- document workflow import and env vars in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a383c647048330aa7073a773ed96a4