### PR TITLE
Add MCP server health checks

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -20,6 +20,7 @@ from .tools.cefr_level import extract_vocab
 from .tools.grammar import check_text
 from .tools.tts import speak_to_file
 from .tools.anki_tool import add_basic_note
+from .tools.health import check_health
 from .orchestration.pipeline import LessonConfig, build_lesson
 from .mcp_tools.lesson import make_card as make_lesson_card
 
@@ -69,6 +70,10 @@ def create_server() -> "Server":  # type: ignore[return-type]
         # единая точка вызова для создания карточки
         return make_lesson_card(word, lang, deck, tag)
 
+    @server.tool("server.health")
+    async def server_health() -> dict:
+        return check_health()
+
     return server
 
 
@@ -91,6 +96,7 @@ def list_tools() -> Dict[str, dict]:
             "args": ["word: str", "lang: str", "deck: str", "tag: str"],
             "returns": "dict",
         },
+        "server.health": {"args": [], "returns": "dict"},
     }
 
 

--- a/app/tools/health.py
+++ b/app/tools/health.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import time
+from typing import Dict
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+CACHE_TTL = 5.0
+_last_result: Dict[str, Dict[str, str]] | None = None
+_last_checked = 0.0
+
+
+def _wrap(status: str, message: str) -> Dict[str, str]:
+    return {"status": status, "message": message}
+
+
+def _check_openrouter(model_env: str) -> Dict[str, str]:
+    api_key = os.getenv("OPENROUTER_API_KEY", "")
+    model = os.getenv(model_env, "")
+    if not api_key or not model:
+        return _wrap("err", "missing OPENROUTER_API_KEY or model")
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        resp = requests.get("https://openrouter.ai/api/v1/models", headers=headers, timeout=5)
+        if resp.status_code >= 500:
+            return _wrap("err", f"HTTP {resp.status_code}")
+        return _wrap("ok", model)
+    except Exception as exc:  # pragma: no cover - network failure
+        return _wrap("err", str(exc))
+
+
+def _check_anki() -> Dict[str, str]:
+    url = os.getenv("ANKI_CONNECT_URL", "http://127.0.0.1:8765")
+    try:
+        resp = requests.post(url, json={"action": "version", "version": 6}, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        ver = data.get("result", "")
+        return _wrap("ok", str(ver))
+    except Exception as exc:  # pragma: no cover - network failure
+        return _wrap("err", str(exc))
+
+
+def _check_tts() -> Dict[str, str]:
+    if importlib.util.find_spec("edge_tts") is None:
+        return _wrap("skip", "edge-tts not installed")
+    return _wrap("ok", "edge-tts")
+
+
+def check_health() -> Dict[str, Dict[str, str]]:
+    global _last_result, _last_checked
+    now = time.time()
+    if _last_result is not None and now - _last_checked < CACHE_TTL:
+        return _last_result
+
+    result = {
+        "openrouter_text": _check_openrouter("OPENROUTER_TEXT_MODEL"),
+        "openrouter_image": _check_openrouter("OPENROUTER_IMAGE_MODEL"),
+        "anki": _check_anki(),
+        "tts": _check_tts(),
+    }
+
+    _last_result = result
+    _last_checked = now
+    return result

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,59 @@
+import importlib.util
+
+import requests
+
+from app.tools import health
+
+
+class DummyResp:
+    def __init__(self, data=None, status=200):
+        self._data = data or {}
+        self.status_code = status
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_check_health(monkeypatch):
+    calls = {"get": 0, "post": 0}
+
+    def fake_get(url, headers=None, timeout=None):
+        calls["get"] += 1
+        return DummyResp()
+
+    def fake_post(url, json=None, timeout=None):
+        calls["post"] += 1
+        return DummyResp({"result": "2.1.0", "error": None})
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+    monkeypatch.setenv("OPENROUTER_TEXT_MODEL", "m-text")
+    monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "m-img")
+    monkeypatch.setenv("ANKI_CONNECT_URL", "http://anki")
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+
+    # сброс кеша
+    health._last_result = None
+    health._last_checked = 0.0
+
+    res1 = health.check_health()
+    assert res1["openrouter_text"]["status"] == "ok"
+    assert res1["openrouter_text"]["message"] == "m-text"
+    assert res1["openrouter_image"]["status"] == "ok"
+    assert res1["openrouter_image"]["message"] == "m-img"
+    assert res1["anki"]["status"] == "ok"
+    assert res1["anki"]["message"] == "2.1.0"
+    assert res1["tts"]["status"] == "ok"
+
+    assert calls["get"] == 2
+    assert calls["post"] == 1
+
+    # повторный вызов использует кеш
+    res2 = health.check_health()
+    assert calls["get"] == 2
+    assert calls["post"] == 1
+    assert res2 == res1


### PR DESCRIPTION
## Summary
- add `check_health` helper for OpenRouter, Anki, and TTS with short-term caching
- expose new `server.health` tool in MCP server
- cover health checks with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a383ad394483309e40f1839d0daffb