### PR TITLE
Добавлены минимальные тесты для основного сценария

### DIFF
--- a/tests/test_anki_connect.py
+++ b/tests/test_anki_connect.py
@@ -1,0 +1,35 @@
+from app.mcp_tools import anki
+
+
+def test_add_anki_note_with_media(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_invoke(action, **params):
+        calls.append((action, params))
+        if action == "storeMediaFile":
+            return params["filename"]
+        if action == "addNote":
+            return 77
+        raise ValueError(action)
+
+    monkeypatch.setattr(anki, "_invoke", fake_invoke)
+
+    media = tmp_path / "pic.png"
+    media.write_bytes(b"data")
+
+    note_id = anki.add_anki_note(
+        front="Hund",
+        back_html="<div>Back</div>",
+        deck="Deck",
+        tags=["tag"],
+        media_path=str(media),
+    )
+
+    assert note_id == 77
+    assert calls[0][0] == "storeMediaFile"
+    assert calls[0][1]["filename"] == "pic.png"
+    assert calls[1][0] == "addNote"
+    note = calls[1][1]["note"]
+    assert note["fields"]["Front"] == "Hund"
+    assert '<img src="pic.png">' in note["fields"]["Back"]
+    assert note["tags"] == ["tag"]

--- a/tests/test_lesson.py
+++ b/tests/test_lesson.py
@@ -1,0 +1,32 @@
+from app.mcp_tools import lesson
+
+
+def test_make_card_no_image(monkeypatch):
+    # Stub out external dependencies
+    monkeypatch.setattr(lesson, "generate_sentence", lambda w: "Der Hund schläft.")
+    monkeypatch.setattr(lesson, "translate_text", lambda text, src, tgt: "Собака спит")
+    monkeypatch.setattr(lesson, "generate_image_file", lambda sentence: "")
+
+    params = {}
+
+    def fake_add_anki_note(front, back_html, deck, tags, media_path):
+        params.update(
+            front=front,
+            back_html=back_html,
+            deck=deck,
+            tags=tags,
+            media_path=media_path,
+        )
+        return 42
+
+    monkeypatch.setattr(lesson, "add_anki_note", fake_add_anki_note)
+
+    result = lesson.make_card("Hund", "de", "Deck", "tag")
+
+    assert result == {
+        "note_id": 42,
+        "front": "Hund",
+        "back": "<div>Перевод: Собака спит</div><div>Satz: Der Hund schläft.</div>",
+        "image": "",
+    }
+    assert params["media_path"] is None

--- a/tests/test_text_tools.py
+++ b/tests/test_text_tools.py
@@ -1,0 +1,21 @@
+from app.mcp_tools import text
+
+
+class DummyLLM:
+    def chat(self, messages):
+        system = messages[0]["content"]
+        if system.startswith("Translate to"):
+            return {"choices": [{"message": {"content": '"собака"'}}]}
+        return {"choices": [{"message": {"content": "Der Hund spielt."}}]}
+
+
+def test_generate_sentence(monkeypatch):
+    monkeypatch.setattr(text, "llm_text", DummyLLM())
+    out = text.generate_sentence("Hund")
+    assert out == "Der Hund spielt."
+
+
+def test_translate_text(monkeypatch):
+    monkeypatch.setattr(text, "llm_text", DummyLLM())
+    out = text.translate_text("Hund", "de", "ru")
+    assert out == "собака"


### PR DESCRIPTION
## Summary
- Добавлен тест make_card без генерации картинки
- Смоделированы ответы OpenRouter для перевода и генерации предложения
- Протестировано добавление заметки в Anki с заглушками storeMediaFile и addNote

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a383b910208330a9646de024b96ba4