### PR TITLE
feat: add unified HTTP helper

### DIFF
--- a/app/mcp_tools/image.py
+++ b/app/mcp_tools/image.py
@@ -9,6 +9,8 @@ from typing import Any
 import requests
 from dotenv import load_dotenv
 
+from app.net.http import request_json
+
 # --- env / config ---
 load_dotenv()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
@@ -42,37 +44,29 @@ def generate_image_file(sentence_de: str) -> str:
         "prompt": _build_prompt(sentence_de),
     }
 
-    # до 3 попыток с экспоненциальной задержкой 1s, 2s
-    for attempt in range(3):
-        try:
-            resp = requests.post(IMAGES_URL, headers=headers, json=payload, timeout=60)
-            resp.raise_for_status()
-            data = resp.json().get("data")
-            if not data:
-                raise ValueError("Empty data from image API")
+    try:
+        data = request_json("POST", IMAGES_URL, headers=headers, json=payload, timeout=60).get(
+            "data"
+        )
+        if not data:
+            raise ValueError("Empty data from image API")
 
-            item = data[0]
-            # предпочтительно b64_json, но поддержим и прямую ссылку
-            if "b64_json" in item and item["b64_json"]:
-                img_bytes = base64.b64decode(item["b64_json"])
-            elif "url" in item and item["url"]:
-                img_resp = requests.get(item["url"], timeout=60)
-                img_resp.raise_for_status()
-                img_bytes = img_resp.content
-            else:
-                raise ValueError("No image payload (b64_json/url) in response")
+        item = data[0]
+        # предпочтительно b64_json, но поддержим и прямую ссылку
+        if "b64_json" in item and item["b64_json"]:
+            img_bytes = base64.b64decode(item["b64_json"])
+        elif "url" in item and item["url"]:
+            img_resp = requests.get(item["url"], timeout=60)
+            img_resp.raise_for_status()
+            img_bytes = img_resp.content
+        else:
+            raise ValueError("No image payload (b64_json/url) in response")
 
-            # стабильное имя + защита от коллизий
-            timestamp = int(time.time())
-            safe_hash = abs(hash(sentence_de)) % (10**12)
-            out_path = MEDIA_DIR / f"img_{safe_hash}_{timestamp}.png"
-            out_path.write_bytes(img_bytes)
-            return str(out_path)
-
-        except Exception:
-            if attempt < 2:
-                time.sleep(2**attempt)
-            else:
-                return ""
-
-    return ""
+        # стабильное имя + защита от коллизий
+        timestamp = int(time.time())
+        safe_hash = abs(hash(sentence_de)) % (10**12)
+        out_path = MEDIA_DIR / f"img_{safe_hash}_{timestamp}.png"
+        out_path.write_bytes(img_bytes)
+        return str(out_path)
+    except Exception:
+        return ""

--- a/app/net/__init__.py
+++ b/app/net/__init__.py
@@ -1,0 +1,3 @@
+from .http import NetworkError, request_json
+
+__all__ = ["NetworkError", "request_json"]

--- a/app/net/http.py
+++ b/app/net/http.py
@@ -1,0 +1,57 @@
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class NetworkError(RuntimeError):
+    """Standard network error with structured details."""
+
+    def __init__(self, code: Any, message: str, details: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"NetworkError(code={self.code!r}, message={self.message!r}, details={self.details!r})"
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    json: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = 30,
+    retries: int = 3,
+    backoff_base: float = 1,
+) -> Dict[str, Any]:
+    """Perform an HTTP request expecting JSON with retries and exponential backoff."""
+
+    last_error: Optional[NetworkError] = None
+    for attempt in range(retries):
+        try:
+            resp = requests.request(
+                method, url, json=json, headers=headers, timeout=timeout
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except requests.HTTPError as exc:  # noqa: PERF203
+            response = exc.response
+            details = {
+                "status_code": getattr(response, "status_code", None),
+                "text": getattr(response, "text", ""),
+            }
+            last_error = NetworkError(details["status_code"], "HTTP error", details)
+        except requests.RequestException as exc:  # network issue/timeout
+            last_error = NetworkError("network", str(exc))
+        except ValueError as exc:  # JSON decoding
+            last_error = NetworkError("json", str(exc))
+
+        if attempt == retries - 1:
+            break
+        time.sleep(backoff_base * (2**attempt))
+
+    assert last_error is not None  # for mypy
+    raise last_error

--- a/app/tools/anki_tool.py
+++ b/app/tools/anki_tool.py
@@ -1,7 +1,9 @@
 import os
-import requests
 from typing import List, Optional
+
 from dotenv import load_dotenv
+
+from app.net.http import NetworkError, request_json
 
 load_dotenv()
 ANKI_URL = os.getenv("ANKI_CONNECT_URL", "http://127.0.0.1:8765")
@@ -9,11 +11,9 @@ ANKI_URL = os.getenv("ANKI_CONNECT_URL", "http://127.0.0.1:8765")
 
 def _invoke(action: str, **params):
     payload = {"action": action, "version": 6, "params": params}
-    r = requests.post(ANKI_URL, json=payload, timeout=15)
-    r.raise_for_status()
-    out = r.json()
+    out = request_json("POST", ANKI_URL, json=payload, timeout=15)
     if out.get("error"):
-        raise RuntimeError(out["error"])
+        raise NetworkError("anki-error", out["error"])
     return out["result"]
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,56 @@
+import time
+
+import pytest
+import requests
+
+from app.net.http import NetworkError, request_json
+
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.text = str(data)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+    def json(self):
+        return self._data
+
+
+def test_request_json_success(monkeypatch):
+    def fake_request(method, url, json=None, headers=None, timeout=None):
+        return DummyResponse({"ok": True})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    assert request_json("GET", "http://example.com") == {"ok": True}
+
+
+def test_request_json_retry(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_request(method, url, json=None, headers=None, timeout=None):
+        if calls["count"] == 0:
+            calls["count"] += 1
+            raise requests.RequestException("boom")
+        return DummyResponse({"ok": True})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    assert request_json("GET", "http://example.com") == {"ok": True}
+
+
+def test_request_json_fail(monkeypatch):
+    def fake_request(method, url, json=None, headers=None, timeout=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    with pytest.raises(NetworkError) as exc:
+        request_json("GET", "http://example.com", retries=3)
+
+    assert exc.value.code == "network"


### PR DESCRIPTION
## Summary
- add NetworkError and request_json helper with retry/backoff
- route OpenRouter and AnkiConnect calls through request_json
- cover HTTP helper with success and retry tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a383a7098c8330bcccbbc7593aca1c