### PR TITLE
docs: add inspector and n8n guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ OPENAI_API_KEY=...
 pytest
 ```
 
+## Дополнительная документация
+
+- [Inspector](docs/INSPECTOR.md)
+- [n8n](docs/N8N.md)
+
 ---
 
 Сделано для быстрых экспериментов.

--- a/docs/INSPECTOR.md
+++ b/docs/INSPECTOR.md
@@ -1,0 +1,35 @@
+# Inspector
+
+Инструмент для взаимодействия с MCP через браузер.
+
+## Установка
+
+1. Установите Node.js.
+2. Установите пакет инспектора:
+
+```bash
+npm install -g @modelcontextprotocol/inspector
+```
+
+## Запуск и подключение к локальному серверу
+
+Следующая команда одновременно поднимет локальный MCP‑сервер через `stdio` и откроет Inspector:
+
+```bash
+npx @modelcontextprotocol/inspector --stdio "python -m app.mcp_server"
+```
+
+Откройте адрес из вывода (обычно `http://localhost:5173`).
+
+## Примеры вызовов
+
+Через веб‑интерфейс можно вызывать зарегистрированные инструменты:
+
+- **server.health** — проверка окружения и доступности зависимостей.
+- **lesson.make_card** с JSON‑аргументами:
+
+```json
+{"word": "Haus", "lang": "de", "deck": "Deutsch::Lektüre", "tag": "demo"}
+```
+
+После выполнения в Anki появится новая карточка (если запущен AnkiConnect).

--- a/docs/N8N.md
+++ b/docs/N8N.md
@@ -1,0 +1,23 @@
+# n8n
+
+Импорт и запуск workflow для языка.
+
+## Переменные окружения
+
+Перед запуском n8n определите:
+
+```bash
+export TELEGRAM_BOT_TOKEN=...   # токен Telegram бота
+export TELEGRAM_CHAT_ID=123456   # ID чата, куда слать сообщения
+export MCP_PROXY_URL=http://localhost:8080  # адрес MCP proxy/bridge
+```
+
+После этого запустите n8n любым удобным способом (`n8n start`, Docker и т.д.).
+
+## Импорт workflow
+
+1. В интерфейсе n8n выберите **Import from File**.
+2. Загрузите файл `workflows/n8n-language-assistant.json` из этого репозитория.
+3. Убедитесь, что в ноде **Telegram** используются переменные окружения `TELEGRAM_BOT_TOKEN` и `TELEGRAM_CHAT_ID`.
+4. Активируйте workflow. Webhook путь указан в ноде `Webhook`.
+5. Отправьте POST с JSON `{"word": "Haus"}` на URL webhook — результат придёт в Telegram.

--- a/workflows/n8n-language-assistant.json
+++ b/workflows/n8n-language-assistant.json
@@ -1,0 +1,80 @@
+{
+  "name": "Language Assistant",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "assistant",
+        "method": "POST",
+        "responseMode": "onReceived"
+      },
+      "id": "1",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$env.MCP_PROXY_URL}}",
+        "responseFormat": "json",
+        "jsonParameters": true,
+        "bodyParametersJson": "={\"tool\": \"lesson.make_card\", \"args\": {\"word\": $json[\"word\"], \"lang\": \"de\", \"deck\": \"Demo::Deck\", \"tag\": \"n8n\"}}"
+      },
+      "id": "2",
+      "name": "MCP Call",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "sendMessage",
+        "chatId": "={{$env.TELEGRAM_CHAT_ID}}",
+        "text": "={{$json.note_id}}"
+      },
+      "id": "3",
+      "name": "Telegram",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [
+        650,
+        300
+      ],
+      "credentials": {
+        "telegramApi": {
+          "apiToken": "={{$env.TELEGRAM_BOT_TOKEN}}"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "MCP Call",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "MCP Call": {
+      "main": [
+        [
+          {
+            "node": "Telegram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document Inspector usage and sample tool calls
- describe n8n workflow import and env variables
- add minimal n8n workflow calling MCP and forwarding result to Telegram

## Testing
- `pytest` *(fails: Missing required environment variables: OPENROUTER_API_KEY, OPENROUTER_TEXT_MODEL, OPENROUTER_IMAGE_MODEL, ANKI_DECK, TELEGRAM_BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68a388f240008330b3d18fac9bec0f53