### PR TITLE
Добавлен мини-e2e тест для make_card

### DIFF
--- a/tests/test_lesson_make_card.py
+++ b/tests/test_lesson_make_card.py
@@ -1,0 +1,33 @@
+import sys
+import types
+
+
+def test_make_card_happy_path(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "x")
+    monkeypatch.setenv("OPENROUTER_TEXT_MODEL", "x")
+    monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "x")
+    monkeypatch.setenv("ANKI_DECK", "Deck")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+
+    fake_text = types.ModuleType("app.mcp_tools.text")
+    fake_text.generate_sentence = lambda w: "Der Hund schläft."
+    fake_text.translate_text = lambda text, src, tgt: "Собака спит"
+    monkeypatch.setitem(sys.modules, "app.mcp_tools.text", fake_text)
+
+    fake_image = types.ModuleType("app.mcp_tools.image")
+    fake_image.generate_image_file = lambda sentence: ""
+    monkeypatch.setitem(sys.modules, "app.mcp_tools.image", fake_image)
+
+    fake_anki = types.ModuleType("app.mcp_tools.anki")
+    fake_anki.add_anki_note = lambda **kwargs: 123
+    monkeypatch.setitem(sys.modules, "app.mcp_tools.anki", fake_anki)
+
+    from app.mcp_tools.lesson import make_card
+
+    result = make_card("Hund", "de", "Deck", "tag")
+
+    assert set(result) == {"note_id", "front", "back", "image"}
+    assert result["note_id"] == 123
+    assert result["front"] == "Hund"
+    assert result["back"] == "<div>Перевод: Собака спит</div><div>Satz: Der Hund schläft.</div>"
+    assert result["image"] == ""


### PR DESCRIPTION
## Summary
- Проверен happy-path make_card без внешних сервисов

## Testing
- `pytest tests/test_lesson_make_card.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a388e9f0fc8330aad00fe079f24b3c