### PR TITLE
Refactor OpenRouter fallback in text tools and add tests

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+from app.mcp_tools import text
+
+
+def test_generate_sentence_fallback(monkeypatch):
+    monkeypatch.setattr(text, "llm_text", None)
+    monkeypatch.setattr(
+        text,
+        "settings",
+        SimpleNamespace(OPENROUTER_API_KEY="k", OPENROUTER_TEXT_MODEL="m"),
+    )
+
+    def fake_request_json(method, url, *, headers=None, json=None, timeout=30):  # noqa: D401
+        return {"choices": [{"message": {"content": "Der Hund rennt schnell zum Park."}}]}
+
+    monkeypatch.setattr(text, "request_json", fake_request_json)
+
+    sentence = text.generate_sentence("Hund")
+    words = sentence.split()
+    assert 6 <= len(words) <= 12
+    assert any("hund" in w.lower() for w in words)
+
+
+def test_translate_text_fallback(monkeypatch):
+    monkeypatch.setattr(text, "llm_text", None)
+    monkeypatch.setattr(
+        text,
+        "settings",
+        SimpleNamespace(OPENROUTER_API_KEY="k", OPENROUTER_TEXT_MODEL="m"),
+    )
+
+    def fake_request_json(method, url, *, headers=None, json=None, timeout=30):  # noqa: D401
+        return {"choices": [{"message": {"content": '"собака"'}}]}
+
+    monkeypatch.setattr(text, "request_json", fake_request_json)
+
+    translated = text.translate_text("Hund", "de", "ru")
+    assert translated == "собака"


### PR DESCRIPTION
## Summary
- Refactor chat helper to always extract content and use `request_json` for OpenRouter fallback
- Add unit tests for sentence generation and translation using mocked OpenRouter responses

## Testing
- ⚠️ `pytest -q` *(fails: NameError in image tool: load_dotenv not defined)*
- ✅ `pytest tests/test_text.py tests/test_text_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a388e315ac8330af287ca3733aba8a