### PR TITLE
Use shared HTTP client for image generation

### DIFF
--- a/app/mcp_tools/image.py
+++ b/app/mcp_tools/image.py
@@ -7,15 +7,8 @@ from typing import Any
 
 import requests
 
-
-from app.settings import settings
-
 from app.net.http import request_json
-
-# --- env / config ---
-load_dotenv()
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
-OPENROUTER_IMAGE_MODEL = os.getenv("OPENROUTER_IMAGE_MODEL", "")
+from app.settings import settings
 
 IMAGES_URL = "https://openrouter.ai/api/v1/images"
 
@@ -34,8 +27,8 @@ def _build_prompt(sentence_de: str) -> str:
 def generate_image_file(sentence_de: str) -> str:
     """Generate and save an image (PNG) that illustrates a simple German sentence.
 
-    Reads OPENROUTER_API_KEY and OPENROUTER_IMAGE_MODEL from environment (.env supported).
-    Returns absolute/relative file path on success, or an empty string on failure.
+    Credentials are taken from :mod:`app.settings`. Returns the path to the
+    saved image on success or an empty string on any failure.
     """
     if not settings.OPENROUTER_API_KEY or not settings.OPENROUTER_IMAGE_MODEL:
         return ""

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,69 @@
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.mcp_tools import image
+
+
+def _prepare(monkeypatch, tmp_path):
+    fake_settings = SimpleNamespace(
+        OPENROUTER_API_KEY="key", OPENROUTER_IMAGE_MODEL="model"
+    )
+    monkeypatch.setattr(image, "settings", fake_settings)
+    monkeypatch.setattr(image, "MEDIA_DIR", tmp_path)
+    monkeypatch.setattr(image.time, "time", lambda: 1)
+
+
+def test_generate_image_b64(monkeypatch, tmp_path):
+    _prepare(monkeypatch, tmp_path)
+    img_bytes = b"fake-bytes"
+    b64 = base64.b64encode(img_bytes).decode()
+
+    def fake_request_json(method, url, headers=None, json=None, timeout=None):
+        return {"data": [{"b64_json": b64}]}
+
+    monkeypatch.setattr(image, "request_json", fake_request_json)
+
+    path = image.generate_image_file("Hallo")
+    p = Path(path)
+    assert p.exists()
+    assert p.read_bytes() == img_bytes
+
+
+def test_generate_image_url(monkeypatch, tmp_path):
+    _prepare(monkeypatch, tmp_path)
+    img_bytes = b"url-bytes"
+
+    def fake_request_json(method, url, headers=None, json=None, timeout=None):
+        return {"data": [{"url": "http://example.com/img.png"}]}
+
+    class DummyResp:
+        def __init__(self, content):
+            self.content = content
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout=None):
+        return DummyResp(img_bytes)
+
+    monkeypatch.setattr(image, "request_json", fake_request_json)
+    monkeypatch.setattr(image.requests, "get", fake_get)
+
+    path = image.generate_image_file("Hallo")
+    p = Path(path)
+    assert p.exists()
+    assert p.read_bytes() == img_bytes
+
+
+def test_generate_image_failure(monkeypatch, tmp_path):
+    _prepare(monkeypatch, tmp_path)
+
+    def fake_request_json(method, url, headers=None, json=None, timeout=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(image, "request_json", fake_request_json)
+
+    path = image.generate_image_file("Hallo")
+    assert path == ""
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- refactor OpenRouter image tool to use shared request_json HTTP layer and settings
- support both `b64_json` and `url` responses, saving images under media/
- add tests covering base64, URL and failure paths

## Testing
- `export OPENROUTER_API_KEY=1 OPENROUTER_TEXT_MODEL=foo OPENROUTER_IMAGE_MODEL=foo ANKI_DECK=foo TELEGRAM_BOT_TOKEN=foo`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a388d7cce88330acc5da7667c8140b