### PR TITLE
feat: add OpenRouter chat client

### DIFF
--- a/app/mcp_tools/openrouter_chat.py
+++ b/app/mcp_tools/openrouter_chat.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import List
+
+from app.net.http import NetworkError, request_json
+from app.settings import settings
+
+CHAT_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def chat(messages: List[dict], model: str | None = None, max_tokens: int = 200) -> str:
+    """Send chat messages to OpenRouter and return the response text."""
+    api_key = settings.OPENROUTER_API_KEY
+    use_model = model or settings.OPENROUTER_TEXT_MODEL
+
+    missing: list[str] = []
+    if not api_key:
+        missing.append("OPENROUTER_API_KEY")
+    if not use_model:
+        missing.append("OPENROUTER_TEXT_MODEL" if model is None else "model")
+    if missing:
+        raise NetworkError("config", "OpenRouter is not configured", {"missing": missing})
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {"model": use_model, "messages": messages, "max_tokens": max_tokens}
+
+    data = request_json("POST", CHAT_URL, headers=headers, json=payload, timeout=30)
+    return data["choices"][0]["message"]["content"]

--- a/tests/test_openrouter_chat.py
+++ b/tests/test_openrouter_chat.py
@@ -1,0 +1,54 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from app.net.http import NetworkError
+
+
+# helper to import module after setting env
+
+def _import_module(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "key")
+    monkeypatch.setenv("OPENROUTER_TEXT_MODEL", "m")
+    monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "img")
+    monkeypatch.setenv("ANKI_DECK", "deck")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    module = importlib.import_module("app.mcp_tools.openrouter_chat")
+    return importlib.reload(module)
+
+
+def test_chat_success(monkeypatch):
+    oc = _import_module(monkeypatch)
+
+    def fake_request(method, url, headers=None, json=None, timeout=None):
+        assert method == "POST"
+        assert json["model"] == "m"
+        assert json["messages"] == [{"role": "user", "content": "hi"}]
+        return {"choices": [{"message": {"content": "hello"}}]}
+
+    monkeypatch.setattr(oc, "request_json", fake_request)
+
+    out = oc.chat([{"role": "user", "content": "hi"}])
+    assert out == "hello"
+
+
+def test_chat_missing_config(monkeypatch):
+    oc = _import_module(monkeypatch)
+
+    # no API key
+    monkeypatch.setattr(
+        oc,
+        "settings",
+        SimpleNamespace(OPENROUTER_API_KEY="", OPENROUTER_TEXT_MODEL="m"),
+    )
+
+    def fail_request(*a, **k):  # should not be called
+        raise AssertionError("request_json should not be called")
+
+    monkeypatch.setattr(oc, "request_json", fail_request)
+
+    with pytest.raises(NetworkError) as exc:
+        oc.chat([{"role": "user", "content": "hi"}])
+
+    assert exc.value.code == "config"


### PR DESCRIPTION
## Summary
- add OpenRouter chat wrapper
- cover OpenRouter chat happy path and config error

## Testing
- `pytest tests/test_openrouter_chat.py -q`
- `pytest -q` *(fails: Missing required environment variables: OPENROUTER_API_KEY, OPENROUTER_TEXT_MODEL, OPENROUTER_IMAGE_MODEL, ANKI_DECK, TELEGRAM_BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68a388d203408330bd20333bc06f6c19