### PR TITLE
Add resilient HTTP request helper

### DIFF
--- a/app/net/http.py
+++ b/app/net/http.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import requests
 
 
-class NetworkError(RuntimeError):
+class NetworkError(Exception):
     """Standard network error with structured details."""
 
     def __init__(self, code: Any, message: str, details: Optional[Dict[str, Any]] = None) -> None:


### PR DESCRIPTION
## Summary
- add `NetworkError` exception with structured details
- implement `request_json` with retries and exponential backoff
- cover success, retry, and failure scenarios with tests

## Testing
- `pytest tests/test_http.py -q`
- `pytest -q` *(fails: Missing required environment variables: OPENROUTER_API_KEY, OPENROUTER_TEXT_MODEL, OPENROUTER_IMAGE_MODEL, ANKI_DECK, TELEGRAM_BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68a388bcaf5c8330911ac09fa518e253