### PR TITLE
docs: add cli and batch guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ pytest
 
 ## Дополнительная документация
 
+- [CLI](docs/CLI.md)
+- [Batch](docs/BATCH.md)
 - [Inspector](docs/INSPECTOR.md)
 - [n8n](docs/N8N.md)
 

--- a/docs/BATCH.md
+++ b/docs/BATCH.md
@@ -1,0 +1,51 @@
+# Batch
+
+Создание нескольких карточек подряд из списка слов.
+
+## Формат данных
+
+`words.csv`:
+
+```csv
+word,lang,deck,tag
+Hund,de,Deutsch::Lektüre,batch
+Haus,de,Deutsch::Lektüre,batch
+```
+
+## Скрипт
+
+```python
+# batch_make_cards.py
+import csv, json, subprocess, sys
+
+with open("words.csv") as f:
+    for row in csv.DictReader(f):
+        cmd = [
+            "python", "cli/make_card.py",
+            "--word", row["word"],
+            "--lang", row["lang"],
+            "--deck", row["deck"],
+            "--tag", row["tag"],
+        ]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        data = json.loads(res.stdout)
+        if data.get("error"):
+            print(f"{row['word']}: {data['error']}", file=sys.stderr)
+        else:
+            print(json.dumps(data, ensure_ascii=False))
+```
+
+Запуск:
+
+```bash
+python batch_make_cards.py > result.jsonl
+```
+
+## Пример ответа
+
+```
+{"note_id": 123, "front": "Hund", "back": "..."}
+{"word": "Haus", "error": "Connection refused"}
+```
+
+Строки с полем `error` стоит сохранить отдельно и повторить позже.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,36 @@
+# CLI
+
+Документы описывают ручной вызов инструмента `lesson.make_card` через простой скрипт.
+
+## Установка
+
+```bash
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Перед запуском создайте файл `.env` с адресом AnkiConnect и ключами для внешних сервисов.
+
+## Пример
+
+```bash
+python cli/make_card.py --word Hund --lang de --deck "Deutsch::Lektüre" --tag manual
+```
+
+Пример вывода:
+
+```json
+{
+  "note_id": 123,
+  "front": "Hund",
+  "back": "<div>Перевод: Собака спит</div><div>Satz: Der Hund schläft.</div>",
+  "image": ""
+}
+```
+
+Параметры:
+
+- `--word` — слово для карточки.
+- `--lang` — код языка (`de`, `en` и др.).
+- `--deck` — целевая колода Anki.
+- `--tag` — тег для заметки.


### PR DESCRIPTION
## Summary
- add standalone CLI and batch usage docs
- link CLI and batch docs from README

## Testing
- `pytest` *(fails: app.net.http.NetworkError, AssertionError in openrouter_chat)*

------
https://chatgpt.com/codex/tasks/task_e_68a38c4b14f88330b0d5c186ef3419c4