### PR TITLE
Add JSONL telemetry logger

### DIFF
--- a/app/telemetry/jsonl.py
+++ b/app/telemetry/jsonl.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+from typing import Any
+
+
+_SENSITIVE_KEYS = {"api_key", "token", "authorization", "password"}
+
+
+def _filter_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Remove sensitive keys from payload (case-insensitive)."""
+    return {k: v for k, v in payload.items() if k.lower() not in _SENSITIVE_KEYS}
+
+
+def log_event(name: str, payload: dict) -> None:
+    """Append a telemetry event as JSON line.
+
+    Args:
+        name: Event name.
+        payload: Event payload dictionary.
+    """
+    path = Path("var/telemetry/events.jsonl")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {"name": name, "payload": _filter_payload(payload)}
+    with path.open("a", encoding="utf-8") as f:
+        json.dump(record, f, ensure_ascii=False)
+        f.write("\n")

--- a/tests/test_telemetry_jsonl.py
+++ b/tests/test_telemetry_jsonl.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from app.telemetry.jsonl import log_event
+
+
+def read_events(base: Path):
+    path = base / "var" / "telemetry" / "events.jsonl"
+    lines = path.read_text().splitlines()
+    return [json.loads(line) for line in lines]
+
+
+def test_log_event_writes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    log_event("foo", {"a": 1})
+    log_event("bar", {"b": 2})
+    events = read_events(tmp_path)
+    assert events == [
+        {"name": "foo", "payload": {"a": 1}},
+        {"name": "bar", "payload": {"b": 2}},
+    ]
+
+
+def test_log_event_filters(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    payload = {
+        "token": "secret",
+        "Authorization": "Bearer x",
+        "API_KEY": "top",
+        "password": "p",
+        "keep": 42,
+    }
+    log_event("secret", payload)
+    events = read_events(tmp_path)
+    assert events == [{"name": "secret", "payload": {"keep": 42}}]


### PR DESCRIPTION
## Summary
- add minimal JSONL telemetry logger that stores events in `var/telemetry/events.jsonl`
- filter sensitive keys (`api_key`, `token`, `authorization`, `password`) before logging
- cover logger with tests for writing and filtering

## Testing
- `pytest -q` *(fails: Missing required environment variable OPENROUTER_API_KEY)*
- `pytest tests/test_telemetry_jsonl.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a38c4019688330b498f4acaa6751ae