### PR TITLE
feat: strip html tags for previews

### DIFF
--- a/app/utils/html_sanitize.py
+++ b/app/utils/html_sanitize.py
@@ -1,0 +1,51 @@
+"""HTML sanitation utilities."""
+from __future__ import annotations
+
+from html.parser import HTMLParser
+import html
+import re
+
+
+class _HTMLStripper(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        if tag.lower() == "br":
+            self._parts.append(" ")
+
+    def handle_startendtag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        if tag.lower() == "br":
+            self._parts.append(" ")
+
+    def handle_data(self, data: str) -> None:  # type: ignore[override]
+        self._parts.append(data)
+
+    def handle_entityref(self, name: str) -> None:  # type: ignore[override]
+        self._parts.append(html.unescape(f"&{name};"))
+
+    def handle_charref(self, name: str) -> None:  # type: ignore[override]
+        self._parts.append(html.unescape(f"&#{name};"))
+
+    def get_data(self) -> str:
+        return "".join(self._parts)
+
+
+def strip_html(text: str) -> str:
+    """Return ``text`` without HTML tags.
+
+    All tags are removed, consecutive whitespace is collapsed into a single
+    space, and ``<br>`` tags are treated as spaces.
+    """
+
+    parser = _HTMLStripper()
+    parser.feed(text)
+    parser.close()
+    result = parser.get_data()
+    result = html.unescape(result)
+    result = re.sub(r"\s+", " ", result)
+    return result.strip()
+
+
+__all__ = ["strip_html"]

--- a/tests/test_html_sanitize.py
+++ b/tests/test_html_sanitize.py
@@ -1,0 +1,18 @@
+import pytest
+
+from app.utils.html_sanitize import strip_html
+
+
+@pytest.mark.parametrize(
+    "html, expected",
+    [
+        ("plain text", "plain text"),
+        ("<b>bold</b> text", "bold text"),
+        ("hello<br>world", "hello world"),
+        ("<p> spaced   \n text </p>", "spaced text"),
+        ("before <img src='x.png' alt='img'> after", "before after"),
+        ("<img src='x.png'>only", "only"),
+    ],
+)
+def test_strip_html(html, expected):
+    assert strip_html(html) == expected


### PR DESCRIPTION
## Summary
- add strip_html utility to remove tags and collapse whitespace
- test html sanitizer against various markup including images

## Testing
- `python -m pytest tests/test_html_sanitize.py -q`
- `python -m pytest -q` *(fails: Missing required environment variable: OPENROUTER_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a38c357e188330abc5095a03b97932