### PR TITLE
Add batch card creation helper

### DIFF
--- a/app/mcp_tools/batch.py
+++ b/app/mcp_tools/batch.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import List, Dict
+
+from .lesson import make_card
+
+
+def make_cards_from_list(words: List[str], lang: str, deck: str, tag: str) -> List[Dict]:
+    """Создать несколько карточек из списка слов.
+
+    Для каждого слова вызывает :func:`make_card`. Если при обработке слова
+    происходит исключение, оно не прерывает цикл, а добавляется в результат в
+    виде словаря ``{"word": word, "error": str(exc)}``.
+    """
+    results: List[Dict] = []
+    for word in words:
+        try:
+            results.append(make_card(word, lang, deck, tag))
+        except Exception as exc:  # pragma: no cover - защитный catch
+            results.append({"word": word, "error": str(exc)})
+    return results

--- a/tests/test_mcp_batch.py
+++ b/tests/test_mcp_batch.py
@@ -1,0 +1,31 @@
+
+def test_make_cards_from_list_handles_errors(monkeypatch):
+    # satisfy settings import
+    monkeypatch.setenv("OPENROUTER_API_KEY", "x")
+    monkeypatch.setenv("OPENROUTER_TEXT_MODEL", "x")
+    monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "x")
+    monkeypatch.setenv("ANKI_DECK", "Deck")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+
+    from app.mcp_tools import batch
+
+    calls = []
+
+    def fake_make_card(word, lang, deck, tag):
+        calls.append(word)
+        if word == "bad":
+            raise RuntimeError("boom")
+        return {"word": word}
+
+    monkeypatch.setattr(batch, "make_card", fake_make_card)
+
+    words = ["good", "bad", "great"]
+    result = batch.make_cards_from_list(words, "de", "Deck", "tag")
+
+    # ensure make_card was called for all words
+    assert calls == words
+    # ensure error for failing word captured
+    assert result[1] == {"word": "bad", "error": "boom"}
+    # ensure successful words return their data
+    assert result[0] == {"word": "good"}
+    assert result[2] == {"word": "great"}


### PR DESCRIPTION
## Summary
- add batch tool to create multiple cards with error capture
- test batch tool handles per-word failures

## Testing
- `pytest tests/test_mcp_batch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38c3ad23c833092aa68cf0c68c242