### PR TITLE
feat: add CLI for manual card creation

### DIFF
--- a/cli/make_card.py
+++ b/cli/make_card.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""CLI для ручного создания карточки Anki."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from app.mcp_tools import lesson
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create Anki card via lesson.make_card")
+    parser.add_argument("--word", required=True, help="Слово для карточки")
+    parser.add_argument(
+        "--lang",
+        choices=["de", "ru", "auto"],
+        default="auto",
+        help="Язык исходного слова (de, ru или auto)",
+    )
+    parser.add_argument("--deck", required=True, help="Имя колоды")
+    parser.add_argument("--tag", required=True, help="Тег для карточки")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    lang = None if args.lang == "auto" else args.lang
+    try:
+        result = lesson.make_card(args.word, lang, args.deck, args.tag)
+    except Exception as exc:  # pragma: no cover - error path
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_make_card.py
+++ b/tests/test_cli_make_card.py
@@ -1,0 +1,33 @@
+import json
+import runpy
+
+
+def test_make_card_cli(monkeypatch, capsys):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "x")
+    monkeypatch.setenv("OPENROUTER_TEXT_MODEL", "x")
+    monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "x")
+    monkeypatch.setenv("ANKI_DECK", "Deck")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+
+    from app.mcp_tools import lesson
+
+    called = {}
+
+    def fake_make_card(word, lang, deck, tag):
+        called['args'] = (word, lang, deck, tag)
+        return {'front': 'Hund', 'back': 'Back', 'image': 'img.png', 'note_id': 42}
+
+    monkeypatch.setattr(lesson, 'make_card', fake_make_card)
+
+    module_globals = runpy.run_path('cli/make_card.py', run_name='__not_main__')
+    exit_code = module_globals['main']([
+        '--word', 'Hund',
+        '--lang', 'de',
+        '--deck', 'Deck',
+        '--tag', 'tag'
+    ])
+
+    assert exit_code == 0
+    assert called['args'] == ('Hund', 'de', 'Deck', 'tag')
+    out = capsys.readouterr().out.strip()
+    assert json.loads(out) == {'front': 'Hund', 'back': 'Back', 'image': 'img.png', 'note_id': 42}


### PR DESCRIPTION
## Summary
- add CLI script to create Anki cards manually
- support parsing card parameters and outputting JSON
- test CLI argument parsing and output with mocked make_card

## Testing
- `pytest tests/test_cli_make_card.py -q`
- `pytest -q` *(fails: NetworkError in tests/test_lesson_make_card.py::test_make_card_happy_path, AssertionError in tests/test_openrouter_chat.py::test_chat_success)*


------
https://chatgpt.com/codex/tasks/task_e_68a38c30e4948330a096589efe8e9fd5