### PR TITLE
feat: add SQLite text cache

### DIFF
--- a/app/cache/text_cache.py
+++ b/app/cache/text_cache.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+
+class TextCache:
+    """Simple key-value cache backed by SQLite."""
+
+    def __init__(self, path: str | Path = "var/text_cache.sqlite") -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(self.path)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS kv (k TEXT PRIMARY KEY, v TEXT, created_at INT)"
+        )
+        self.conn.commit()
+
+    def get(self, key: str) -> str | None:
+        cur = self.conn.execute("SELECT v FROM kv WHERE k = ?", (key,))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+    def set(self, key: str, value: str) -> None:
+        self.conn.execute(
+            "INSERT INTO kv (k, v, created_at) VALUES (?, ?, ?) "
+            "ON CONFLICT(k) DO UPDATE SET v=excluded.v, created_at=excluded.created_at",
+            (key, value, int(time.time())),
+        )
+        self.conn.commit()

--- a/tests/test_text_cache.py
+++ b/tests/test_text_cache.py
@@ -1,0 +1,35 @@
+import sqlite3
+
+from app.cache.text_cache import TextCache
+
+
+def test_put_get(tmp_path):
+    db = tmp_path / "cache.sqlite"
+    cache = TextCache(db)
+    key = "abc"
+    value = "result"
+
+    assert cache.get(key) is None
+    cache.set(key, value)
+
+    # reopen to ensure data persisted
+    cache2 = TextCache(db)
+    assert cache2.get(key) == value
+
+
+def test_idempotent(tmp_path):
+    db = tmp_path / "cache.sqlite"
+    cache = TextCache(db)
+    key = "abc"
+    value = "result"
+
+    cache.set(key, value)
+    cache.set(key, value)
+
+    assert cache.get(key) == value
+
+    # ensure single row in table
+    conn = sqlite3.connect(db)
+    count = conn.execute("SELECT COUNT(*) FROM kv").fetchone()[0]
+    conn.close()
+    assert count == 1


### PR DESCRIPTION
## Summary
- add SQLite-backed TextCache for caching text responses
- test TextCache persistence and idempotent behavior

## Testing
- `pytest tests/test_text_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38c2c6bc88330a6f068d1f544e179