### PR TITLE
Ensure target word inclusion in generated sentences

### DIFF
--- a/tests/test_sentence_validator.py
+++ b/tests/test_sentence_validator.py
@@ -1,0 +1,48 @@
+import pytest
+
+from app.mcp_tools import text
+from app.net.http import NetworkError
+
+
+def test_includes_target_normalization():
+    assert text._includes_target("Straße", "Die Strasse ist breit.")
+    assert not text._includes_target("Straße", "Das Haus ist groß.")
+    assert text._includes_target("Hund", "Der Hund! spielt.")
+    assert not text._includes_target("Hund", "Hundert Leute kommen.")
+
+
+def test_generate_sentence_retries(monkeypatch):
+    responses = [
+        "Die Katze schläft.",
+        "Ein Vogel fliegt.",
+        "Der Hund spielt im Garten.",
+    ]
+    calls = []
+
+    def fake_chat(messages):
+        calls.append(1)
+        return responses[len(calls) - 1]
+
+    monkeypatch.setattr(text, "_chat", fake_chat)
+    sentence = text.generate_sentence("Hund")
+    assert sentence == "Der Hund spielt im Garten."
+    assert len(calls) == 3
+
+
+def test_generate_sentence_raises_after_three_attempts(monkeypatch):
+    responses = [
+        "Die Katze schläft.",
+        "Ein Vogel fliegt.",
+        "Der Vogel sitzt.",
+    ]
+    calls = []
+
+    def fake_chat(messages):
+        calls.append(1)
+        return responses[len(calls) - 1]
+
+    monkeypatch.setattr(text, "_chat", fake_chat)
+    with pytest.raises(NetworkError) as exc:
+        text.generate_sentence("Hund")
+    assert exc.value.code == "validation"
+    assert len(calls) == 3


### PR DESCRIPTION
## Summary
- normalize sentences and target words and verify inclusion
- retry sentence generation up to three times and raise validation error
- add tests for sentence validation and retry logic

## Testing
- `OPENROUTER_API_KEY=1 OPENROUTER_TEXT_MODEL=1 OPENROUTER_IMAGE_MODEL=1 ANKI_DECK=1 TELEGRAM_BOT_TOKEN=1 pytest tests/test_sentence_validator.py tests/test_text.py -q`
- `OPENROUTER_API_KEY=1 OPENROUTER_TEXT_MODEL=1 OPENROUTER_IMAGE_MODEL=1 ANKI_DECK=1 TELEGRAM_BOT_TOKEN=1 pytest -q` *(fails: test_make_card_happy_path, test_chat_success)*

------
https://chatgpt.com/codex/tasks/task_e_68a38c2666988330ad162412131b04b5