### PR TITLE
feat: add GenAPI HTTP client with tests

### DIFF
--- a/app/net/__init__.py
+++ b/app/net/__init__.py
@@ -1,3 +1,26 @@
 from .http import NetworkError, request_json
+from .genapi_client import (
+    GenAPIClient,
+    GenAPIError,
+    GenAPIBadRequest,
+    GenAPIUnauthorized,
+    GenAPIPaymentRequired,
+    GenAPINotFound,
+    GenAPISessionExpired,
+    GenAPIServiceUnavailable,
+    GenAPITaskFailed,
+)
 
-__all__ = ["NetworkError", "request_json"]
+__all__ = [
+    "NetworkError",
+    "request_json",
+    "GenAPIClient",
+    "GenAPIError",
+    "GenAPIBadRequest",
+    "GenAPIUnauthorized",
+    "GenAPIPaymentRequired",
+    "GenAPINotFound",
+    "GenAPISessionExpired",
+    "GenAPIServiceUnavailable",
+    "GenAPITaskFailed",
+]

--- a/app/net/genapi_client.py
+++ b/app/net/genapi_client.py
@@ -1,0 +1,153 @@
+import logging
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+__all__ = [
+    "GenAPIClient",
+    "GenAPIError",
+    "GenAPIBadRequest",
+    "GenAPIUnauthorized",
+    "GenAPIPaymentRequired",
+    "GenAPINotFound",
+    "GenAPISessionExpired",
+    "GenAPIServiceUnavailable",
+    "GenAPITaskFailed",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class GenAPIError(Exception):
+    """Base exception for GenAPI errors."""
+
+    def __init__(self, message: str, *, status_code: Optional[int] = None, details: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.details = details or {}
+
+
+class GenAPIBadRequest(GenAPIError):
+    pass
+
+
+class GenAPIUnauthorized(GenAPIError):
+    pass
+
+
+class GenAPIPaymentRequired(GenAPIError):
+    pass
+
+
+class GenAPINotFound(GenAPIError):
+    pass
+
+
+class GenAPISessionExpired(GenAPIError):
+    pass
+
+
+class GenAPIServiceUnavailable(GenAPIError):
+    pass
+
+
+class GenAPITaskFailed(GenAPIError):
+    pass
+
+
+_ERROR_MAP = {
+    400: GenAPIBadRequest,
+    401: GenAPIUnauthorized,
+    402: GenAPIPaymentRequired,
+    404: GenAPINotFound,
+    419: GenAPISessionExpired,
+    503: GenAPIServiceUnavailable,
+}
+
+
+def _extract_details(response: requests.Response) -> Dict[str, Any]:
+    try:
+        return response.json()  # type: ignore[return-value]
+    except ValueError:
+        return {"text": response.text}
+
+
+class GenAPIClient:
+    """Low-level HTTP client for GenAPI."""
+
+    BASE_URL = "https://gen-api.ru"
+    NETWORKS_PATH = "/api/v1/networks/{model_id}"
+    REQUESTS_PATH = "/api/v1/requests/{request_id}"
+
+    def __init__(self, token: str, *, timeout: int = 30, retries: int = 3) -> None:
+        self.token = token
+        self.timeout = timeout
+        self.retries = retries
+
+    @property
+    def base_headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def create_generation_task(
+        self,
+        model_id: str,
+        prompt: str,
+        is_sync: bool,
+        callback_url: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.BASE_URL}{self.NETWORKS_PATH.format(model_id=model_id)}"
+        payload: Dict[str, Any] = {"prompt": prompt, "is_sync": is_sync}
+        if callback_url:
+            payload["callback_url"] = callback_url
+        if extra:
+            payload.update(extra)
+
+        response = requests.post(url, json=payload, headers=self.base_headers, timeout=self.timeout)
+        if response.status_code in _ERROR_MAP:
+            raise _ERROR_MAP[response.status_code](
+                "HTTP error",
+                status_code=response.status_code,
+                details=_extract_details(response),
+            )
+        response.raise_for_status()
+        data = response.json()
+        request_id = data.get("request_id")
+        if request_id:
+            logger.info("Created generation task", extra={"request_id": request_id})
+        return data
+
+    def get_task_status(self, request_id: str) -> Dict[str, Any]:
+        url = f"{self.BASE_URL}{self.REQUESTS_PATH.format(request_id=request_id)}"
+        headers = self.base_headers
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                logger.debug("Checking task status", extra={"request_id": request_id, "attempt": attempt})
+                response = requests.get(url, headers=headers, timeout=self.timeout)
+            except (requests.Timeout, requests.RequestException) as exc:
+                if attempt >= self.retries:
+                    raise GenAPIError(str(exc)) from exc
+                time.sleep(1 * (2 ** (attempt - 1)))
+                continue
+
+            if response.status_code in _ERROR_MAP:
+                raise _ERROR_MAP[response.status_code](
+                    "HTTP error",
+                    status_code=response.status_code,
+                    details=_extract_details(response),
+                )
+            response.raise_for_status()
+            data = response.json()
+            status = data.get("status")
+            if status == "processing":
+                time.sleep(1)
+                continue
+            if status == "failed":
+                raise GenAPITaskFailed("Task failed", details=data)
+            if status == "success":
+                logger.info("Task completed", extra={"request_id": request_id})
+                return data
+            raise GenAPIError(f"Unknown status: {status}", details=data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ python-telegram-bot>=21
 youtube-transcript-api>=0.6
 edge-tts>=6.1.12
 pytest>=8.0
+responses>=0.25
 # Optional / suggested:
 # language-tool-python>=2.7.1  # if you prefer the client wrapper
 # fastapi>=0.112 uvicorn>=0.30 # if you want a web API surface

--- a/tests/test_genapi_client.py
+++ b/tests/test_genapi_client.py
@@ -1,0 +1,87 @@
+import time
+import requests
+import responses
+import pytest
+
+from app.net.genapi_client import (
+    GenAPIClient,
+    GenAPIUnauthorized,
+    GenAPIPaymentRequired,
+    GenAPINotFound,
+    GenAPIServiceUnavailable,
+)
+
+
+def make_client():
+    return GenAPIClient(token="TOKEN", timeout=1, retries=3)
+
+
+@responses.activate
+def test_get_task_status_processing_to_success(monkeypatch):
+    client = make_client()
+    request_id = "abc"
+    url = f"{client.BASE_URL}/api/v1/requests/{request_id}"
+
+    responses.add(responses.GET, url, json={"status": "processing"}, status=200)
+    responses.add(responses.GET, url, json={"status": "success", "result": {"img": "data"}}, status=200)
+
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    result = client.get_task_status(request_id)
+    assert result["status"] == "success"
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_create_generation_task_401():
+    client = make_client()
+    url = f"{client.BASE_URL}/api/v1/networks/model"
+    responses.add(responses.POST, url, json={"detail": "unauthorized"}, status=401)
+    with pytest.raises(GenAPIUnauthorized):
+        client.create_generation_task("model", "prompt", False)
+
+
+@responses.activate
+def test_create_generation_task_402():
+    client = make_client()
+    url = f"{client.BASE_URL}/api/v1/networks/model"
+    responses.add(responses.POST, url, json={"detail": "payment"}, status=402)
+    with pytest.raises(GenAPIPaymentRequired):
+        client.create_generation_task("model", "prompt", False)
+
+
+@responses.activate
+def test_get_task_status_404():
+    client = make_client()
+    request_id = "missing"
+    url = f"{client.BASE_URL}/api/v1/requests/{request_id}"
+    responses.add(responses.GET, url, json={"detail": "not found"}, status=404)
+    with pytest.raises(GenAPINotFound):
+        client.get_task_status(request_id)
+
+
+@responses.activate
+def test_get_task_status_503():
+    client = make_client()
+    request_id = "svc"
+    url = f"{client.BASE_URL}/api/v1/requests/{request_id}"
+    responses.add(responses.GET, url, json={"detail": "busy"}, status=503)
+    with pytest.raises(GenAPIServiceUnavailable):
+        client.get_task_status(request_id)
+
+
+@responses.activate
+def test_get_task_status_timeouts(monkeypatch):
+    client = make_client()
+    request_id = "slow"
+    url = f"{client.BASE_URL}/api/v1/requests/{request_id}"
+
+    responses.add(responses.GET, url, body=requests.exceptions.Timeout())
+    responses.add(responses.GET, url, body=requests.exceptions.Timeout())
+    responses.add(responses.GET, url, json={"status": "success"}, status=200)
+
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    result = client.get_task_status(request_id)
+    assert result["status"] == "success"
+    assert len(responses.calls) == 3


### PR DESCRIPTION
## Summary
- implement low-level GenAPI client with retry logic and error mapping
- expose client in net package and add responses for testing
- cover success, HTTP errors and timeout retries

## Testing
- `pytest tests/test_genapi_client.py -q`
- `pytest -q` *(fails: Missing required environment variable OPENROUTER_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a3901ab5b0833094155fe223288784