### PR TITLE
feat: add reference image support to GenAPI client

### DIFF
--- a/tests/test_genapi_client.py
+++ b/tests/test_genapi_client.py
@@ -1,3 +1,4 @@
+import json
 import time
 import requests
 import responses
@@ -14,6 +15,71 @@ from app.net.genapi_client import (
 
 def make_client():
     return GenAPIClient(token="TOKEN", timeout=1, retries=3)
+
+
+@responses.activate
+def test_create_generation_task_json_no_image():
+    client = make_client()
+    url = f"{client.BASE_URL}/api/v1/networks/model"
+    responses.add(responses.POST, url, json={"ok": True}, status=200)
+    client.create_generation_task("model", "prompt", False)
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert call.request.headers["Content-Type"] == "application/json"
+    body = json.loads(call.request.body)
+    assert body["prompt"] == "prompt"
+    assert "image_url" not in body and "image_b64" not in body
+
+
+@responses.activate
+def test_create_generation_task_image_url():
+    client = make_client()
+    url = f"{client.BASE_URL}/api/v1/networks/model"
+    responses.add(responses.POST, url, json={"ok": True}, status=200)
+    img_url = "http://img"
+    client.create_generation_task("model", "prompt", False, ref_image_url=img_url)
+    call = responses.calls[0]
+    body = json.loads(call.request.body)
+    assert body["image_url"] == img_url
+    assert call.request.headers["Content-Type"] == "application/json"
+
+
+@responses.activate
+def test_create_generation_task_image_b64():
+    client = make_client()
+    url = f"{client.BASE_URL}/api/v1/networks/model"
+    responses.add(responses.POST, url, json={"ok": True}, status=200)
+    b64 = "YWJj"  # 'abc'
+    client.create_generation_task("model", "prompt", False, ref_image_b64=b64)
+    call = responses.calls[0]
+    body = json.loads(call.request.body)
+    assert body["image_b64"] == b64
+    assert call.request.headers["Content-Type"] == "application/json"
+
+
+@responses.activate
+def test_create_generation_task_image_file(tmp_path):
+    client = make_client()
+    url = f"{client.BASE_URL}/api/v1/networks/model"
+    responses.add(responses.POST, url, json={"ok": True}, status=200)
+    img_path = tmp_path / "img.png"
+    img_path.write_bytes(b"123")
+    client.create_generation_task("model", "prompt", False, ref_image_path=str(img_path))
+    call = responses.calls[0]
+    assert call.request.headers["Content-Type"].startswith("multipart/form-data")
+    body = call.request.body
+    assert b'name="image"' in body
+    assert b'filename="img.png"' in body
+
+
+@responses.activate
+def test_create_generation_task_image_conflict():
+    client = make_client()
+    with pytest.raises(ValueError):
+        client.create_generation_task(
+            "model", "prompt", False, ref_image_url="http://img", ref_image_b64="abc"
+        )
+    assert len(responses.calls) == 0
 
 
 @responses.activate


### PR DESCRIPTION
## Summary
- allow creating generation tasks with optional reference images
- support reference image via URL, base64 or local file upload
- test reference image handling and error cases

## Testing
- `pytest` *(fails: AttributeError in lesson tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a39425ed248330b2af285b104437b6