### PR TITLE
chore: add todo for ref image

### DIFF
--- a/app/mcp_tools/lesson.py
+++ b/app/mcp_tools/lesson.py
@@ -19,6 +19,7 @@ def make_card(
     lang: Optional[str],
     deck: str,
     tag: str = "tg-auto",
+    # TODO: ref_image: str | bytes | None = None
 ) -> Dict[str, str | int]:
     """Полный цикл создания карточки Anki из одного слова.
 
@@ -55,6 +56,8 @@ def make_card(
     # 5) Пытаемся сгенерировать картинку (может вернуть пустую строку)
     provider = os.getenv("IMAGE_PROVIDER", "openrouter").strip().lower()
     if provider == "genapi" and hasattr(image_mod, "generate_image_file_genapi"):
+        # TODO: при добавлении аргумента ref_image в make_card
+        #       прокинуть его в generate_image_file_genapi(sentence_de, ref_image=ref_image)
         img_path = image_mod.generate_image_file_genapi(sentence_de) or ""
     elif provider == "none":
         img_path = ""


### PR DESCRIPTION
## Summary
- note future ref image parameter in make_card
- outline passing ref_image to genapi when implemented

## Testing
- `pytest` *(fails: module has no attribute 'generate_sentence')*

------
https://chatgpt.com/codex/tasks/task_e_68a3943428708330ba0e5cab1841429b