### PR TITLE
feat: allow configuring GenAPI image quality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ TELEGRAM_BOT_TOKEN=
 GENAPI_API_KEY=
 GENAPI_MODEL_ID=gpt-image-1
 GENAPI_BASE_URL=https://api.gen-api.ru
+GENAPI_QUALITY=high # one of: high|medium|low (affects cost & detail)
 GENAPI_IS_SYNC=false
 GENAPI_POLL_INTERVAL_MS=1200
 GENAPI_POLL_TIMEOUT_MS=60000

--- a/README.md
+++ b/README.md
@@ -76,10 +76,15 @@ python -m bot.main
 ```dotenv
 LANGUAGETOOL_URL=http://localhost:8010
 ANKI_CONNECT_URL=http://127.0.0.1:8765
+GENAPI_QUALITY=high  # high|medium|low
 # Необязательно
 DEEPL_API_KEY=...
 OPENAI_API_KEY=...
 ```
+
+`GENAPI_QUALITY` определяет уровень детализации и стоимость генерации
+изображений через GenAPI: `high`, `medium` или `low`. Значение
+некейс‑сенситивно; при отсутствии параметра используется `high`.
 
 ## n8n workflow
 

--- a/app/mcp_tools/image_genapi.py
+++ b/app/mcp_tools/image_genapi.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, Tuple
 
 import requests
+from app.settings import settings
 
 # external client functions; they will be patched in tests
 try:  # pragma: no cover - optional dependency
@@ -124,9 +125,16 @@ def generate_image_file_genapi(
 
     prompt = f"Иллюстрируй смысл простого немецкого предложения без текста: {sentence_de}"
 
-    kwargs: Dict[str, Any] = {"model_id": model_id, "prompt": prompt, "is_sync": is_sync}
+    quality = settings.GENAPI_QUALITY
+    kwargs: Dict[str, Any] = {
+        "model_id": model_id,
+        "prompt": prompt,
+        "is_sync": is_sync,
+        "quality": quality,
+    }
     if callback_url:
         kwargs["callback_url"] = callback_url
+    logger.info("image.gen: model=%s quality=%s", model_id, quality)
 
     # reference image handling
     ref_payload: Dict[str, str] = {}

--- a/tests/test_image_genapi.py
+++ b/tests/test_image_genapi.py
@@ -7,6 +7,7 @@ os.environ.setdefault("OPENROUTER_TEXT_MODEL","m")
 os.environ.setdefault("OPENROUTER_IMAGE_MODEL","m")
 os.environ.setdefault("ANKI_DECK","d")
 os.environ.setdefault("TELEGRAM_BOT_TOKEN","t")
+os.environ.setdefault("GENAPI_API_KEY","g")
 
 from app.mcp_tools import image_genapi
 

--- a/tests/test_image_genapi_reference.py
+++ b/tests/test_image_genapi_reference.py
@@ -94,6 +94,18 @@ def test_reference_bytes(monkeypatch, tmp_path):
     assert recorder["image_b64"] == expected
 
 
+def test_quality_param(monkeypatch, tmp_path):
+    _setup_env(monkeypatch, tmp_path)
+    recorder = {}
+    _fake_create(monkeypatch, _dummy_resp_bytes(), recorder)
+    monkeypatch.setattr(
+        image_genapi, "settings", type("S", (), {"GENAPI_QUALITY": "medium"})()
+    )
+    path = image_genapi.generate_image_file_genapi("Hallo")
+    assert Path(path).exists()
+    assert recorder["quality"] == "medium"
+
+
 def test_reference_size_limit(monkeypatch, tmp_path, caplog):
     _setup_env(monkeypatch, tmp_path)
     monkeypatch.setenv("GENAPI_ALLOWED_IMAGE_TYPES", "image/png")

--- a/tests/test_lesson_make_card.py
+++ b/tests/test_lesson_make_card.py
@@ -37,5 +37,8 @@ def test_make_card_happy_path(monkeypatch):
     assert set(result) == {"note_id", "front", "back", "image"}
     assert result["note_id"] == 123
     assert result["front"] == "Hund"
-    assert result["back"] == "<div>Перевод: Собака спит</div><div>Satz: Der Hund schläфт.</div>".replace("шлäфт", "schläft")
+    assert (
+        result["back"]
+        == "<div>Перевод: Собака спит</div><div>Satz: Der Hund schläft.</div>"
+    )
     assert result["image"] == ""

--- a/tests/test_settings_genapi_quality.py
+++ b/tests/test_settings_genapi_quality.py
@@ -1,0 +1,45 @@
+import importlib
+import pytest
+
+
+_BASE_ENV = {
+    "OPENROUTER_API_KEY": "k",
+    "OPENROUTER_TEXT_MODEL": "t",
+    "OPENROUTER_IMAGE_MODEL": "i",
+    "ANKI_DECK": "d",
+    "TELEGRAM_BOT_TOKEN": "x",
+    "GENAPI_API_KEY": "g",
+}
+
+
+def _load(monkeypatch, quality: str | None):
+    for key, val in _BASE_ENV.items():
+        monkeypatch.setenv(key, val)
+    if quality is None:
+        monkeypatch.delenv("GENAPI_QUALITY", raising=False)
+    else:
+        monkeypatch.setenv("GENAPI_QUALITY", quality)
+    import app.settings as settings_module
+    return importlib.reload(settings_module)
+
+
+def test_valid_values(monkeypatch):
+    for q in ("high", "medium", "low"):
+        settings_module = _load(monkeypatch, q)
+        assert settings_module.settings.GENAPI_QUALITY == q
+
+
+def test_invalid_values(monkeypatch):
+    for q in ("h", "med", "LOWER", "123"):
+        with pytest.raises(RuntimeError):
+            _load(monkeypatch, q)
+
+
+def test_default_and_normalization(monkeypatch):
+    mod = _load(monkeypatch, None)
+    assert mod.settings.GENAPI_QUALITY == "high"
+    mod = _load(monkeypatch, "")
+    assert mod.settings.GENAPI_QUALITY == "high"
+    mod = _load(monkeypatch, "HIGH")
+    assert mod.settings.GENAPI_QUALITY == "high"
+


### PR DESCRIPTION
## Summary
- add `GENAPI_QUALITY` setting with validation and default
- pass quality parameter to GenAPI image payload and log it
- document quality option in README and `.env.example`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a396c45ab083309e9061560de71737