### PR TITLE
Use official mcp SDK with graceful fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-dotenv>=1.0
 python-telegram-bot>=21
 youtube-transcript-api>=0.6
 edge-tts>=6.1.12
+mcp>=0.4
 pytest>=8.0
 responses>=0.25
 # Optional / suggested:


### PR DESCRIPTION
## Summary
- switch server to the `mcp` package
- log MCP SDK version on startup
- document `mcp` dependency

## Testing
- `OPENROUTER_API_KEY=1 OPENROUTER_TEXT_MODEL=1 OPENROUTER_IMAGE_MODEL=1 ANKI_DECK=1 TELEGRAM_BOT_TOKEN=1 GENAPI_API_KEY=1 python -m app.mcp_server` *(fails: MCP SDK ('mcp') is not installed. Run: pip install mcp)*
- `OPENROUTER_API_KEY=1 OPENROUTER_TEXT_MODEL=1 OPENROUTER_IMAGE_MODEL=1 ANKI_DECK=1 TELEGRAM_BOT_TOKEN=1 GENAPI_API_KEY=1 timeout 5 python - <<'PY'
import logging, asyncio
logging.basicConfig(level=logging.INFO)
import app.mcp_server
asyncio.run(app.mcp_server.run())
PY
`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39922ef6c833087bbdb42aa75a38b