### PR TITLE
fix: update GenAPI image API

### DIFF
--- a/app/mcp_tools/health_genapi.py
+++ b/app/mcp_tools/health_genapi.py
@@ -9,7 +9,7 @@ import requests
 
 from app.settings import settings
 
-IMAGES_URL = "https://api.gen-api.ru/v1/images"
+IMAGES_URL = "https://api.gen-api.ru/v1/images/generate"
 
 logger = logging.getLogger(__name__)
 
@@ -26,12 +26,10 @@ def genapi_check() -> Dict[str, Any]:
         "prompt": "test",
         "size": settings.GENAPI_SIZE,
         "quality": settings.GENAPI_QUALITY,
-        "output_format": settings.GENAPI_OUTPUT_FORMAT,
+        "background": settings.GENAPI_BACKGROUND,
+        "response_format": "b64_json",
         "n": 1,
-        "sync": False,
     }
-    if settings.GENAPI_CALLBACK_URL is not None:
-        payload["callback_url"] = settings.GENAPI_CALLBACK_URL
 
     try:
         resp = requests.post(IMAGES_URL, headers=headers, json=payload, timeout=10)

--- a/app/mcp_tools/image.py
+++ b/app/mcp_tools/image.py
@@ -12,7 +12,8 @@ import requests
 
 from app.settings import settings
 
-IMAGES_URL = "https://api.gen-api.ru/v1/images"
+# endpoint согласно документации GPT Images API
+IMAGES_URL = "https://api.gen-api.ru/v1/images/generate"
 
 MEDIA_DIR = Path("media")
 MEDIA_DIR.mkdir(exist_ok=True)
@@ -46,12 +47,10 @@ def generate_image_file(sentence_de: str) -> str:
         "prompt": _build_prompt(sentence_de),
         "size": settings.GENAPI_SIZE,
         "quality": settings.GENAPI_QUALITY,
-        "output_format": settings.GENAPI_OUTPUT_FORMAT,
+        "background": settings.GENAPI_BACKGROUND,
+        "response_format": "b64_json",
         "n": 1,
-        "sync": settings.GENAPI_IS_SYNC,
     }
-    if settings.GENAPI_CALLBACK_URL is not None:
-        payload["callback_url"] = settings.GENAPI_CALLBACK_URL
 
     try:
         resp = requests.post(IMAGES_URL, headers=headers, json=payload, timeout=60)

--- a/app/settings.py
+++ b/app/settings.py
@@ -28,7 +28,7 @@ class Settings(BaseModel):
     GENAPI_MODEL_ID: str = "gpt-image-1"
     GENAPI_SIZE: str = "1024x1024"
     GENAPI_QUALITY: str = "low"
-    GENAPI_OUTPUT_FORMAT: str = "png"
+    GENAPI_BACKGROUND: str = "transparent"
     GENAPI_IS_SYNC: bool = True
     GENAPI_CALLBACK_URL: str | None = None
 
@@ -57,7 +57,7 @@ def _load_settings() -> Settings:
             "GENAPI_MODEL_ID": os.environ.get("GENAPI_MODEL_ID", "gpt-image-1"),
             "GENAPI_SIZE": os.environ.get("GENAPI_SIZE", "1024x1024"),
             "GENAPI_QUALITY": os.environ.get("GENAPI_QUALITY", "low"),
-            "GENAPI_OUTPUT_FORMAT": os.environ.get("GENAPI_OUTPUT_FORMAT", "png"),
+            "GENAPI_BACKGROUND": os.environ.get("GENAPI_BACKGROUND", "transparent"),
             "GENAPI_IS_SYNC": os.environ.get("GENAPI_IS_SYNC", "true").lower()
             in {"1", "true", "yes"},
             "GENAPI_CALLBACK_URL": os.environ.get("GENAPI_CALLBACK_URL") or None,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -17,7 +17,7 @@
 | `GENAPI_MODEL_ID` | нет (по умолчанию `gpt-image-1`) | Модель для генерации изображений. |
 | `GENAPI_SIZE` | нет (по умолчанию `1024x1024`) | Размер изображений. |
 | `GENAPI_QUALITY` | нет (по умолчанию `low`) | Качество изображения (`low`, `medium`, `high`). |
-| `GENAPI_OUTPUT_FORMAT` | нет (по умолчанию `png`) | Формат выходного файла. |
+| `GENAPI_BACKGROUND` | нет (по умолчанию `transparent`) | Цвет фона генерации (`white` или `transparent`). |
 | `GENAPI_IS_SYNC` | нет (по умолчанию `true`) | Синхронный режим генерации. |
 | `GENAPI_CALLBACK_URL` | нет | URL для асинхронного callback'а. |
 

--- a/tests/test_health_genapi.py
+++ b/tests/test_health_genapi.py
@@ -9,7 +9,7 @@ def _cfg():
         GENAPI_MODEL_ID="m",
         GENAPI_SIZE="1024x1024",
         GENAPI_QUALITY="low",
-        GENAPI_OUTPUT_FORMAT="png",
+        GENAPI_BACKGROUND="transparent",
         GENAPI_CALLBACK_URL=None,
     )
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -11,7 +11,7 @@ def _prepare(monkeypatch, tmp_path, sync=True):
         GENAPI_MODEL_ID="m",
         GENAPI_SIZE="1024x1024",
         GENAPI_QUALITY="low",
-        GENAPI_OUTPUT_FORMAT="png",
+        GENAPI_BACKGROUND="transparent",
         GENAPI_IS_SYNC=sync,
         GENAPI_CALLBACK_URL=None,
     )

--- a/tests/test_lesson_make_card_image.py
+++ b/tests/test_lesson_make_card_image.py
@@ -33,7 +33,7 @@ def _prepare(monkeypatch, tmp_path):
         GENAPI_MODEL_ID="m",
         GENAPI_SIZE="1024x1024",
         GENAPI_QUALITY="low",
-        GENAPI_OUTPUT_FORMAT="png",
+        GENAPI_BACKGROUND="transparent",
         GENAPI_IS_SYNC=True,
         GENAPI_CALLBACK_URL=None,
     )


### PR DESCRIPTION
## Summary
- update GenAPI image generator endpoint to `/v1/images/generate`
- support background color parameter via `GENAPI_BACKGROUND`
- adjust health check and documentation for new GPT Images API

## Testing
- `OPENROUTER_API_KEY=k OPENROUTER_TEXT_MODEL=t ANKI_DECK=d TELEGRAM_BOT_TOKEN=x pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3a845f2408330bb490955cc31da3d