### PR TITLE
Handle empty fields before creating Anki notes

### DIFF
--- a/app/mcp_tools/lesson.py
+++ b/app/mcp_tools/lesson.py
@@ -74,11 +74,21 @@ def make_card(
             # слово было RU → переводим в DE
             word_de = translate(word, "ru", "de")
 
+        if not word_de.strip():
+            logger.error("empty fields", extra={"step": "lesson.make_card"})
+            raise EmptyFieldsError("front is empty")
+
         # 3) Генерируем B1-предложение с этим словом
         sentence_de = gen_sentence(word_de)
+        if not sentence_de.strip():
+            logger.error("empty fields", extra={"step": "lesson.make_card"})
+            raise EmptyFieldsError("sentence is empty")
 
         # 4) Переводим предложение на RU (для Back)
         translation_ru = translate(sentence_de, "de", "ru")
+        if not translation_ru.strip():
+            logger.error("empty fields", extra={"step": "lesson.make_card"})
+            raise EmptyFieldsError("translation is empty")
 
         # 5) Пытаемся сгенерировать картинку (может вернуть пустую строку)
         img_path = generate_image_file(sentence_de) or ""
@@ -91,9 +101,9 @@ def make_card(
         if img_path:
             back_html += f'<img src="{img_path}">'  # already includes media/
 
-        if not word_de.strip() or not back_html.strip():
-            logger.error("empty fields", extra={"step": "anki.add_note"})
-            raise EmptyFieldsError("front or back is empty")
+        if not back_html.strip():
+            logger.error("empty fields", extra={"step": "lesson.make_card"})
+            raise EmptyFieldsError("back is empty")
 
         # 7) Добавляем карточку в Anki
         note_id = add_note(

--- a/tests/test_lesson_make_card.py
+++ b/tests/test_lesson_make_card.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import importlib
+import pytest
 
 
 def test_make_card_happy_path(monkeypatch):
@@ -42,3 +43,29 @@ def test_make_card_happy_path(monkeypatch):
     )
     assert result["image"] == ""
     assert result["message"] == "Карточка создана без изображения"
+
+
+def test_make_card_empty_fields(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "x")
+    monkeypatch.setenv("OPENROUTER_TEXT_MODEL", "x")
+    monkeypatch.setenv("ANKI_DECK", "Deck")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+    monkeypatch.setenv("GENAPI_API_KEY", "x")
+
+    fake_text = types.ModuleType("app.mcp_tools.text")
+    fake_text.generate_sentence = lambda w: ""
+    fake_text.translate_text = lambda text, src, tgt: ""
+    monkeypatch.setitem(sys.modules, "app.mcp_tools.text", fake_text)
+
+    fake_image = types.ModuleType("app.mcp_tools.image")
+    fake_image.generate_image_file = lambda sentence: ""
+    monkeypatch.setitem(sys.modules, "app.mcp_tools.image", fake_image)
+
+    fake_anki = types.ModuleType("app.mcp_tools.anki")
+    fake_anki.add_anki_note = lambda **kwargs: 123
+    monkeypatch.setitem(sys.modules, "app.mcp_tools.anki", fake_anki)
+
+    lesson = importlib.reload(importlib.import_module("app.mcp_tools.lesson"))
+
+    with pytest.raises(lesson.EmptyFieldsError):
+        lesson.make_card("Hund", "de", "Deck", "tag")


### PR DESCRIPTION
## Summary
- validate word, sentence and translation strings before creating Anki notes
- add regression test for empty field handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3ae52e49083308a06f06c28a67cee